### PR TITLE
Issue #30: Stop Clearing DB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,11 @@ flyway {
     locations = ['filesystem:db/migration']
 }
 
-/* Migrate DB when stage task runs. */
+/*
+ * Migrate DB when stage task runs.
+ * NOTE: If it is desired to ever wipe the DB, run the flywayClean task.
+ */
 task stage() {
-    dependsOn flywayClean
     dependsOn flywayMigrate
 }
 


### PR DESCRIPTION
* Removes flywayClean gradle task from stage task now that schema is more stable.

Closes #30 

NOTE: We cannot edit V1 DB script anymore once this is merged!
Also, developers wanting to clear their DB will need to run `./gradlew flywayClean` to do so.